### PR TITLE
Fixed fields with dot not showing in tables

### DIFF
--- a/src/client/datatable.tsx
+++ b/src/client/datatable.tsx
@@ -164,6 +164,7 @@ function DataTable(props: { columnDefs: any; rowData: any }) {
                 rowMultiSelectWithClick={false}
                 onCellDoubleClicked={onCellDoubleClicked}
                 onRowSelected={onRowSelected}
+                suppressFieldDotNotation={true}
             ></AgGridReact>
             {detailsVisible && detailsJson && (
                 <ReactJson src={detailsJson} displayDataTypes={false} displayObjectSize={false} />


### PR DESCRIPTION
Fixed a bug where a values of a field with a "." would not be shown in the table

e.g.,
<img width="1109" alt="Screenshot 2023-12-30 at 15 13 37" src="https://github.com/notebookPowerTools/vscode-kusto/assets/6839369/dcde0af0-f4eb-43a7-9d9b-ecf2bf10bb2c">
