### PR TITLE
Enabled cell text selection to allow copy from cell

### DIFF
--- a/src/client/datatable.tsx
+++ b/src/client/datatable.tsx
@@ -160,6 +160,7 @@ function DataTable(props: { columnDefs: any; rowData: any }) {
                 defaultColDef={{ resizable: true, filter: true, sortable: true, floatingFilter: true }}
                 columnDefs={props.columnDefs}
                 rowData={props.rowData}
+                enableCellTextSelection={true}
                 rowSelection="multiple"
                 rowMultiSelectWithClick={false}
                 onCellDoubleClicked={onCellDoubleClicked}


### PR DESCRIPTION
With enableCellTextSelection, it is possible to select text inside a cell and copy it.
For example 
<img width="1622" alt="Screenshot 2024-01-05 at 12 10 21" src="https://github.com/notebookPowerTools/vscode-kusto/assets/6839369/72eab6d7-058a-4891-b09d-247d973bc1ae">
